### PR TITLE
AutoFix PR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.1.RELEASE</version>
+        <version>2.1.0.RELEASE</version>
     </parent>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
            <plugin>
         		<groupId>org.apache.maven.plugins</groupId>
         		<artifactId>maven-compiler-plugin</artifactId>
-        		<version>3.6.1</version>
+            <version>2.6.7.5</version>
         		<configuration>
           			<source>1.8</source>
           			<target>1.8</target>


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.
As long as it is open, subsequent scans and generated fixes to this same branch will be added to it as new commits.


Each commit fixes one vulnerability.

Some manual intervention might be required before merging this PR.

## Project Information

* Name: [shiftleft-java-demo](https://app.stg.shiftleft.io/apps/shiftleft-java-demo)
* Branch: demo-branch-1785828345
* Pull Request Language: 

## Findings/Vulnerabilities Fixed


**Finding [365](https://app.stg.shiftleft.io/apps/shiftleft-java-demo/vulnerabilities?appId=shiftleft-java-demo&findingId=365&scan=2):** pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.6

### 📝 Description
**Upgrade Version:** `2.6.7.5`

**Summary:**
CVE-2020-36182 affects jackson-databind versions before 2.9.10.8 and 2.6.7.5, involving a deserialization vulnerability related to org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS. This upgrade resolves the serialization gadget vulnerability by updating com.fasterxml.jackson.core:jackson-databind to the safe version 2.6.7.5.

> [!IMPORTANT]
> **Potential Breaking Changes:** Patch version upgrade - breaking changes are unlikely, but testing is recommended.
> Please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 0, High: 1, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![high][high-badge] | `8.1` | `2.6.7.5` | [CVE-2020-36182](https://www.cve.org/CVERecord?id=CVE-2020-36182) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

