### PR TITLE
AutoFix PR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.1.RELEASE</version>
+        <version>1.5.10.RELEASE</version>
     </parent>
     <dependencies>
         <dependency>


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.
As long as it is open, subsequent scans and generated fixes to this same branch will be added to it as new commits.


Each commit fixes one vulnerability.

Some manual intervention might be required before merging this PR.

## Project Information

* Name: [shiftleft-java-demo](https://app.stg.shiftleft.io/apps/shiftleft-java-demo)
* Branch: demo-branch-1785828345
* Pull Request Language: 

## Findings/Vulnerabilities Fixed


**Finding [428](https://app.stg.shiftleft.io/apps/shiftleft-java-demo/vulnerabilities?appId=shiftleft-java-demo&findingId=428&scan=2):** pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.11

### 📝 Description
**Upgrade Version:** `9.0.0.M19`

**Summary:**
CVE-2017-5651 affects Apache Tomcat embedded core versions 8.5.0 to 8.5.12, which can cause response mix-up and unexpected errors due to a regression in send file processing. This upgrade resolves the vulnerability by updating the Spring Boot parent version to 1.5.10.RELEASE, which transitively updates tomcat-embed-core to 9.0.0.M19.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a major version upgrade (8.5.11 → 9.0.0.M19) and Spring Boot parent upgrade (1.5.1 → 1.5.10), which may include breaking changes in Tomcat's API and behavior.
> Please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 1, High: 0, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![critical][critical-badge] | `9.8` | `9.0.0.M19` | [CVE-2017-5651](https://www.cve.org/CVERecord?id=CVE-2017-5651) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

