### PR TITLE
AutoFix PR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
+            <version>2.7.9.4</version>
     </dependencies>
     <properties>
         <java.version>1.8</java.version>


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.
As long as it is open, subsequent scans and generated fixes to this same branch will be added to it as new commits.


Each commit fixes one vulnerability.

Some manual intervention might be required before merging this PR.

## Project Information

* Name: [shiftleft-java-demo](https://app.stg.shiftleft.io/apps/shiftleft-java-demo)
* Branch: demo-branch-1785828345
* Pull Request Language: 

## Findings/Vulnerabilities Fixed


**Finding [363](https://app.stg.shiftleft.io/apps/shiftleft-java-demo/vulnerabilities?appId=shiftleft-java-demo&findingId=363&scan=2):** pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.6

### 📝 Description
**Upgrade Version:** `2.7.9.4`

**Summary:**
This PR upgrades `jackson-databind` from `2.8.6` to `2.7.9.4` to resolve CVE-2018-12023. The vulnerability allows remote code execution when Default Typing is enabled and the Oracle JDBC jar is present in the classpath, as attackers can exploit LDAP deserialization to execute malicious payloads.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a downgrade from 2.8.6 to 2.7.9.4, which may introduce compatibility issues. Please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 0, High: 1, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![high][high-badge] | `7.5` | `2.7.9.4` | [CVE-2018-12023](https://www.cve.org/CVERecord?id=CVE-2018-12023) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

