### PR TITLE
AutoFix PR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
+            <version>2.7.9.5</version>
     </dependencies>
     <properties>
         <java.version>1.8</java.version>


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.
As long as it is open, subsequent scans and generated fixes to this same branch will be added to it as new commits.


Each commit fixes one vulnerability.

Some manual intervention might be required before merging this PR.

## Project Information

* Name: [shiftleft-java-demo](https://app.stg.shiftleft.io/apps/shiftleft-java-demo)
* Branch: demo-branch-1785828345
* Pull Request Language: 

## Findings/Vulnerabilities Fixed


**Finding [393](https://app.stg.shiftleft.io/apps/shiftleft-java-demo/vulnerabilities?appId=shiftleft-java-demo&findingId=393&scan=2):** pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.6

### 📝 Description
**Upgrade Version:** `2.7.9.5`

**Summary:**
This upgrade addresses CVE-2018-19361, a critical polymorphic deserialization vulnerability in jackson-databind 2.8.6. The vulnerability allows attackers to exploit the openjpa class for potential remote code execution. Upgrading to version 2.7.9.5 resolves this security issue.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a minor version downgrade (2.8.6 → 2.7.9.5) which may include behavioral changes or removed features introduced in 2.8.x. Please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 1, High: 0, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![critical][critical-badge] | `9.8` | `2.7.9.5` | [CVE-2018-19361](https://www.cve.org/CVERecord?id=CVE-2018-19361) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

