### PR TITLE
AutoFix PR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
            <plugin>
         		<groupId>org.apache.maven.plugins</groupId>
         		<artifactId>maven-compiler-plugin</artifactId>
-        		<version>3.6.1</version>
+            <version>2.12.7.1</version>
         		<configuration>
           			<source>1.8</source>
           			<target>1.8</target>


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.
As long as it is open, subsequent scans and generated fixes to this same branch will be added to it as new commits.


Each commit fixes one vulnerability.

Some manual intervention might be required before merging this PR.

## Project Information

* Name: [shiftleft-java-demo](https://app.stg.shiftleft.io/apps/shiftleft-java-demo)
* Branch: demo-branch-1785828345
* Pull Request Language: 

## Findings/Vulnerabilities Fixed


**Finding [389](https://app.stg.shiftleft.io/apps/shiftleft-java-demo/vulnerabilities?appId=shiftleft-java-demo&findingId=389&scan=2):** pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.6

### 📝 Description
**Upgrade Version:** `2.12.7.1`

**Summary:**
CVE-2022-42003 affects jackson-databind versions 2.4.0-rc1 through 2.12.7.0 and certain 2.13.x versions due to resource exhaustion from deep wrapper array nesting when UNWRAP_SINGLE_VALUE_ARRAYS is enabled. Upgrading to 2.12.7.1 resolves this vulnerability by adding proper validation in primitive value deserializers.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a minor version upgrade (2.8.6 → 2.12.7.1) which may introduce breaking changes. The upgrade spans multiple major and minor versions, so behavioral changes and API modifications are likely.
> Please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 0, High: 1, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![high][high-badge] | `7.5` | `2.12.7.1` | [CVE-2022-42003](https://www.cve.org/CVERecord?id=CVE-2022-42003) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

