### PR TITLE
AutoFix PR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.1.RELEASE</version>
+        <version>1.5.13.RELEASE</version>
     </parent>
     <dependencies>
         <dependency>


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.
As long as it is open, subsequent scans and generated fixes to this same branch will be added to it as new commits.


Each commit fixes one vulnerability.

Some manual intervention might be required before merging this PR.

## Project Information

* Name: [shiftleft-java-demo](https://app.stg.shiftleft.io/apps/shiftleft-java-demo)
* Branch: demo-branch-1785828345
* Pull Request Language: 

## Findings/Vulnerabilities Fixed


**Finding [527](https://app.stg.shiftleft.io/apps/shiftleft-java-demo/vulnerabilities?appId=shiftleft-java-demo&findingId=527&scan=2):** pkg:maven/org.springframework/spring-core@4.3.6.RELEASE

### 📝 Description
**Upgrade Version:** `4.3.16`

**Summary:**
CVE-2018-1275 is a critical remote code execution vulnerability in Spring Framework versions prior to 4.3.16. A malicious user can craft a message to the STOMP broker that leads to remote code execution. This upgrade resolves the vulnerability by updating the spring-boot-starter-parent to version 1.5.13.RELEASE, which transitively upgrades spring-core to 4.3.16.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a minor version upgrade that is unlikely to introduce breaking changes.
> Please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 1, High: 0, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![critical][critical-badge] | `9.8` | `4.3.16` | [CVE-2018-1275](https://www.cve.org/CVERecord?id=CVE-2018-1275) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

