### PR TITLE
fix: upgrade spring-data-commons to 1.13.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.1.RELEASE</version>
+        <version>1.5.11.RELEASE</version>
     </parent>
     <dependencies>
         <dependency>


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding **[550](https://app.shiftleft.io/apps/shiftleft-java-demo/vulnerabilities?appId=shiftleft-java-demo&findingId=550&scan=1)**




### 📝 Description
**Upgrade Version:** `1.13.11`

**Summary:**
Spring Data Commons versions prior to 1.13.11 contain a critical remote code execution vulnerability (CVE-2018-1273) caused by improper neutralization of special elements in the property binder. An unauthenticated attacker can exploit this by supplying specially crafted request parameters to execute arbitrary code. This upgrade to version 1.13.11 resolves the vulnerability.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a patch version upgrade (1.13.0 → 1.13.11) which typically contains only bug fixes and security patches with minimal risk of breaking changes.
> Please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 1, High: 0, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![critical][critical-badge] | `9.8` | `1.13.11` | [CVE-2018-1273](https://www.cve.org/CVERecord?id=CVE-2018-1273) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

