### PR TITLE
fix: upgrade commons-io to 2.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
     		<groupId>commons-io</groupId>
     		<artifactId>commons-io</artifactId>
-    		<version>2.5</version>
+    		<version>2.14.0</version>
 		</dependency>
         <dependency>
     		<groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding **[413](https://app.stg.shiftleft.io/apps/shiftleft-java-demo/vulnerabilities?appId=shiftleft-java-demo&findingId=413&scan=1)**




### 📝 Description
**Upgrade Version:** `2.14.0`

**Summary:**
This upgrade resolves CVE-2024-47554, an Uncontrolled Resource Consumption vulnerability in Apache Commons IO. The `org.apache.commons.io.input.XmlStreamReader` class may excessively consume CPU resources when processing maliciously crafted input. Upgrading to version 2.14.0 eliminates this security risk.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a major version upgrade from 2.5 to 2.14.0, which may include breaking changes. Please review the [Apache Commons IO release notes](https://commons.apache.org/proper/commons-io/changes-report.html) and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 0, High: 1, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![high][high-badge] | `7.5` | `2.14.0` | [CVE-2024-47554](https://www.cve.org/CVERecord?id=CVE-2024-47554) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

