### PR TITLE
fix: upgrade org.springframework:spring-web to 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-        </dependency>
+            <version>6.0.0</version>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding **[493](https://app.stg.shiftleft.io/apps/shiftleft-java-demo/vulnerabilities?appId=shiftleft-java-demo&findingId=493&scan=3)**




### 📝 Description
**Upgrade Version:** `6.0.0`

**Summary:**
This upgrade addresses CVE-2016-1000027, a critical remote code execution (RCE) vulnerability in spring-web versions prior to 6.0.0. The vulnerability stems from unsafe Java deserialization of untrusted data. Version 6.0.0 completely removes the vulnerable deserialization classes, eliminating the attack vector.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a major version upgrade from 4.3.6.RELEASE to 6.0.0, which likely includes breaking changes. Spring Framework 6.0 requires Java 17+ and Jakarta EE 9+ (namespace change from javax.* to jakarta.*). Please review the [Spring Framework 6.0 migration guide](https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x) and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 1, High: 0, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![critical][critical-badge] | `9.8` | `6.0.0` | [CVE-2016-1000027](https://www.cve.org/CVERecord?id=CVE-2016-1000027) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

