### PR TITLE
fix: upgrade spring-boot-starter-parent to 2.5.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.1.RELEASE</version>
+        <version>2.5.12</version>
     </parent>
     <dependencies>
         <dependency>


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding **[544](https://app.stg.shiftleft.io/apps/shiftleft-java-demo/vulnerabilities?appId=shiftleft-java-demo&findingId=544&scan=3)**




### 📝 Description
**Upgrade Version:** `2.5.12`

**Summary:**
This upgrade addresses CVE-2022-22965 (Spring4Shell), a critical remote code execution vulnerability in Spring Framework. The vulnerability affects Spring MVC/WebFlux applications running on JDK 9+ with Tomcat as a WAR deployment, allowing attackers to execute arbitrary code via data binding exploitation.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a major version upgrade from 1.5.1.RELEASE to 2.5.12, which likely includes breaking changes in APIs, configuration, and behavior. Spring Boot 2.x introduced significant changes from 1.x including migration to Java 8+ baseline, updated dependency versions, configuration property changes, and actuator endpoint modifications.
> Please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 1, High: 0, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![critical][critical-badge] | `9.8` | `2.5.12` | [CVE-2022-22965](https://www.cve.org/CVERecord?id=CVE-2022-22965) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

