### PR TITLE
fix: upgrade jackson-databind to 2.8.11.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
+            <version>2.8.11.3</version>
     </dependencies>
     <properties>
         <java.version>1.8</java.version>


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding **[370](https://app.stg.shiftleft.io/apps/shiftleft-java-demo/vulnerabilities?appId=shiftleft-java-demo&findingId=370&scan=1)**




### 📝 Description
**Upgrade Version:** `2.8.11.3`

**Summary:**
CVE-2018-14721 is a critical vulnerability in jackson-databind versions prior to 2.9.7 that allows remote attackers to conduct server-side request forgery (SSRF) attacks through polymorphic deserialization of the axis2-jaxws class. Upgrading `com.fasterxml.jackson.core:jackson-databind` from version 2.8.6 (inherited from spring-boot-starter-parent 1.5.1.RELEASE) to 2.8.11.3 resolves this vulnerability by blocking the vulnerable class from deserialization.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a patch version upgrade which typically maintains backward compatibility. However, security fixes in jackson-databind may affect code that relies on previously vulnerable deserialization behaviors.
> Please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 1, High: 0, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![critical][critical-badge] | `10` | `2.8.11.3` | [CVE-2018-14721](https://www.cve.org/CVERecord?id=CVE-2018-14721) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

